### PR TITLE
Add 2016-05-06 meeting announcement

### DIFF
--- a/announcements/_posts/2016-05-04-week-14-letsencrypt.md
+++ b/announcements/_posts/2016-05-04-week-14-letsencrypt.md
@@ -6,7 +6,13 @@ layout: post
 
 Welcome to Week 14, RITluggers! Hope everyone's week is going well so far.
 
-In case you missed it at the last meeting, our new Eboard was officially elected at our last meeting. The 2016-2017 President is Justin W. Flory and Vice President is Solomon Rubin. For this week and the next, we'll be getting a headstart into running the club.
+In case you missed it, our new Eboard was officially elected at our last meeting. The 2016-2017 President is Justin W. Flory and Vice President is Solomon Rubin. For this week and the next, we'll be getting a headstart into running the club.
+
+As of this week, we also have a few more ways that you can get involved with RITlug! We set up a bridge between our IRC channel and our new Telegram group. Here's the links for all of them if you want to join us!
+
+* Facebook: https://www.facebook.com/groups/RITLUG/
+* Telegram: https://telegram.me/joinchat/BVxlKADKpMbhHtgxKkdjSQ
+* IRC:      https://webchat.freenode.net/?channels=ritlug
 
 This week's topic covers a hot topic in the system administration world (and even more than just sysadmin): LetsEncrypt! If you haven't heard about LetsEncrypt, it is free and open source software that runs as a free Certificate Authority. What does that mean in English? It lets anyone get free SSL certificates for your domains. In our talk, we're going to introduce it, how it works, and most importantly, how to get your own certificate!
 

--- a/announcements/_posts/2016-05-04-week-14-letsencrypt.md
+++ b/announcements/_posts/2016-05-04-week-14-letsencrypt.md
@@ -1,0 +1,15 @@
+---
+author: Justin W. Flory
+title: "Spring Week 14: LetsEncrypt"
+layout: post
+---
+
+Welcome to Week 14, RITluggers! Hope everyone's week is going well so far.
+
+In case you missed it at the last meeting, our new Eboard was officially elected at our last meeting. The 2016-2017 President is Justin W. Flory and Vice President is Solomon Rubin. For this week and the next, we'll be getting a headstart into running the club.
+
+This week's topic covers a hot topic in the system administration world (and even more than just sysadmin): LetsEncrypt! If you haven't heard about LetsEncrypt, it is free and open source software that runs as a free Certificate Authority. What does that mean in English? It lets anyone get free SSL certificates for your domains. In our talk, we're going to introduce it, how it works, and most importantly, how to get your own certificate!
+
+The first part of the meeting will be a short tech talk on how it works and how to run it. After the talk, we'll have a live workshop for anyone who wants to set up LetsEncrypt on their servers. Make sure to bring a laptop and your SSH key if you want to get help setting it up! If you don't have a server or domain you can use it on, we'll also have a live demo as Solomon uses it on one of his servers.
+
+As usual, after the presentation and meeting, the floor will be open to more discussion about LetsEncrypt, other FOSS topics, Q&A, technical help, and time to dig in to any other projects you want to share. If you have a cool project or know about something awesome in the FOSS world, let us know if you want to give a talk! We'd love to learn about it.


### PR DESCRIPTION
This commit adds in the latest meeting announcement for our upcoming meeting on May 6th. The meeting topic will be LetsEncrypt and will have a talk, followed by a workshop, followed by an open floor.

@Serubin: Let me know if this looks good to you for this week!

@thenaterhood / @repkam09: If you get a chance to take a look, let me know if this all checks out!