### PR TITLE
Fix og:image meta tag attributes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,7 +21,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="{{ site.description }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="og:image" content="{{ site.url }}/img/ritlug-large.png" />
+    <meta property="og:image" content="{{ site.url }}/img/ritlug-large.png" />
     <title>{{ page.title }} | RITlug</title>
 
     <!-- Add to homescreen for Chrome on Android -->


### PR DESCRIPTION
Reddit's preview image is currently wrong:
![screenshot_2016-05-06_13 19 59](https://cloud.githubusercontent.com/assets/5891442/15080663/42a06da4-138d-11e6-8062-297412e07e38.png)

This fixes the meta tag responsible.