### PR TITLE
Announcement for selecting a meeting time next year

### DIFF
--- a/announcements/_posts/2016-05-27-summer-new-meeting-time.md
+++ b/announcements/_posts/2016-05-27-summer-new-meeting-time.md
@@ -1,0 +1,21 @@
+---
+author: Justin W. Flory
+title: "Choosing next year's RITlug meeting time"
+layout: post
+---
+
+Hey RITluggers! Hope everyone's semesters ended well and that you're enjoying (or working, or studying, or traveling, or whatever it might be) this summer so far.
+
+We're already looking ahead to next year, and we want to get your input about choosing a new meeting time based on what everyone's schedules look like next year. Hopefully some of you have a more clear idea of what your schedules might look like next semester. If so, awesome! Please submit what times you'd like RITlug to meet next year in the below poll.
+
+* Select your free times: http://whenisgood.net/rit/ritlug/2161-meetings
+
+If you don't know what your schedule is looking like next year yet, no worries. We'll send out another reminder closer to the beginning of next semester to finalize a time.
+
+It may be summertime, but RITlug is still active over the summer! You can get more involved with RITlug either through the IRC channel or the newer Telegram group (they're bridged together, so either one works as well as the other). Here's the links for all relevant communication places!
+
+* Facebook: https://www.facebook.com/groups/RITLUG/
+* Telegram: https://telegram.me/joinchat/BVxlKADKpMbhHtgxKkdjSQ
+* IRC:      https://webchat.freenode.net/?channels=ritlug
+
+Looking forward to seeing you all next semester. If you're an alumni or just graduated, don't be a stranger! Visitors are always welcome, and if you'd like to give a talk sometime, you're always welcome to stop by. Thanks everyone!


### PR DESCRIPTION
Just a friendly announcement email with a [WhenIsGood poll](http://whenisgood.net/rit/ritlug/2161-meetings) for choosing a new meeting time for the 2016-2017 academic year.

@Serubin, care to take a peek? If it looks good, I'll send it out via TheLink next.