### PR TITLE
Update meeting time, place, and location; fix Telegram link; add IRC webchat

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title: RIT Linux Users Group
-email: ngl3477@rit.edu
+email: ritlug@rit.edu
 description: > # this means to ignore newlines until "baseurl:"
   Official site of the RIT Linux Users Group (RITlug). Find all
   our talks and announcements here.
@@ -13,6 +13,6 @@ markdown: kramdown
 # location. They will appear in pages as they are typed, so it
 # is recommended that you follow the format already here when
 # updating them.
-ritlug-time: 4-6PM
-ritlug-place: GOL/70-2520
-ritlug-day: Friday
+ritlug-time: 4:00PM - 6:00PM
+ritlug-place: GOL/70-2620
+ritlug-day: other Friday

--- a/get-involved.md
+++ b/get-involved.md
@@ -3,7 +3,7 @@ layout: page
 title: Get Involved
 ---
 
-Meetings are open to anyone interested, new members and old. RITlug meets {{ site.ritlug-day }}s, {{ site.ritlug-time }} in {{ site.ritlug-place }}. If you can't make the whole time, that's fine! Meetings typically have a presentation first, then we open the floor to discussion and technical help. Interested? Just show up!
+Meetings are open to anyone interested, new members and old. RITlug meets on every {{ site.ritlug-day }}, {{ site.ritlug-time }} in {{ site.ritlug-place }}. If you can't make the whole time, that's fine! Meetings typically have a presentation first, then we open the floor to discussion and technical help. Interested? Just show up!
 
 Looking for more information? Email us at rit.edu, our name is ritlug.
 
@@ -15,11 +15,11 @@ Looking for more information? Email us at rit.edu, our name is ritlug.
 
 ##### Discussion
 * Come to meetings!
+* [Telegram](https://telegram.me/ritlugclub)
+* [IRC Channel](ircs://irc.freenode.net/ritlug) ([webchat](https://webchat.freenode.net/?channels=ritlug))
 * [Facebook page](https://facebook.com/groups/RITlug) (restricted to past and present RIT students and staff only, sorry!)
-* [IRC Channel](ircs://irc.freenode.net/ritlug)
 * [Twitter](https://twitter.com/RITlug)
 * [Reddit](https://www.reddit.com/r/RITlug)
-* [Telegram](https://telegram.me/joinchat/BVxlKADKpMbhHtgxKkdjSQ)
 
 ##### Open Source Code and Governance
 * [Github Organization](https://github.com/RITlug) (club governing documents, website, and projects)
@@ -27,6 +27,5 @@ Looking for more information? Email us at rit.edu, our name is ritlug.
 ##### Events
 * Weekly Meetings on {{ site.ritlug-day }}s, {{ site.ritlug-time }}
 * RIT Club Fairs
-* Occasional RIT FOSS Events
+* Occasional [FOSS@MAGIC](http://foss.rit.edu) Events
 * [ImagineRIT](https://rit.edu/imagine)
-


### PR DESCRIPTION
This PR does exactly as it says:

* Adds the current meeting time, date, place, and location to the `get-involved` page
* Fixes the Telegram link on the `get-involved` page (changed after migrating to supergroup)
* Add link to IRC webchat on `get-involved` page