### PR TITLE
Circleci test jekyll build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,20 +4,36 @@ jobs:
     docker:
       - image: circleci/ruby:2.4.1-node
     steps:
+      # Checkout source code
       - checkout
 
-      # Restore bundle cache
-      - type: cache-restore
-        key: ritlug-site-{{ checksum "Gemfile.lock" }}
-
+      # Restore cache
+      - restore_cache:
+          keys:
+            # Find a cache corresponding to this specific Gemfile.lock checksum
+            # when this file is changed, this key will fail
+            - cache-build-{{ checksum "Gemfile.lock" }}
+            # Fallback cache
+            - cache-build
+            
       # Bundle install dependencies
-      - run: bundle install --path vendor/bundle
-
-      # Store bundle cache
-      - type: cache-save
-        key: ritlug-site-{{ checksum "Gemfile.lock" }}
-        paths:
-          - vendor/bundle
-
+      - run:
+          name: bundle-install
+          command: 'bundle install --path vendor/bundle'
+      
       # Build
-      - run: bundle exec jekyll build
+      - run:
+          name: jekyll-build
+          command: 'bundle exec jekyll build'
+      
+      # Save cache
+      - save_cache:
+          # Gemfile.lock cache
+          key: cache-build-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      - save_cache:
+          # Fallback cache
+          key: cache-build
+          paths:
+            - vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.4.1-node
+    steps:
+      - checkout
+
+      # Restore bundle cache
+      - type: cache-restore
+        key: rails-demo-{{ checksum "Gemfile.lock" }}
+
+      # Bundle install dependencies
+      - run: bundle install --path vendor/bundle
+
+      # Store bundle cache
+      - type: cache-save
+        key: rails-demo-{{ checksum "Gemfile.lock" }}
+        paths:
+          - vendor/bundle
+
+      # Build
+      - run: bundle exec jekyll build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,14 @@ jobs:
 
       # Restore bundle cache
       - type: cache-restore
-        key: rails-demo-{{ checksum "Gemfile.lock" }}
+        key: ritlug-site-{{ checksum "Gemfile.lock" }}
 
       # Bundle install dependencies
       - run: bundle install --path vendor/bundle
 
       # Store bundle cache
       - type: cache-save
-        key: rails-demo-{{ checksum "Gemfile.lock" }}
+        key: ritlug-site-{{ checksum "Gemfile.lock" }}
         paths:
           - vendor/bundle
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Gemfile.lock
 node_modules/
 pyenv/
 _site/
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ output/
 
 gems/
 gembin/
-Gemfile.lock
 .bundle/
 node_modules/
 pyenv/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem 'jekyll', '3.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    colorator (1.1.0)
+    ffi (1.9.18-x64-mingw32)
+    forwardable-extended (2.6.0)
+    jekyll (3.5.1)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.14.0)
+    liquid (4.0.0)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (2.0.5)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (1.11.1)
+    safe_yaml (1.0.4)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  x64-mingw32
+
+DEPENDENCIES
+  jekyll (= 3.5.1)
+
+BUNDLED WITH
+   1.15.3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ritlug.github.io
 
-[![Circle CI](https://circleci.com/gh/patkub/ritlug.github.io.svg?style=shield&circle-token=750a96e7410a2300c741356993092a6d066d7ee6)](https://circleci.com/gh/patkub/ritlug.github.io)
+[![CircleCI](https://circleci.com/gh/patkub/ritlug.github.io/tree/circleci.svg?style=shield&circle-token=750a96e7410a2300c741356993092a6d066d7ee6)](https://circleci.com/gh/patkub/ritlug.github.io/tree/circleci)
 
 RITlug's current website.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # ritlug.github.io
+
+[![Circle CI](https://circleci.com/gh/patkub/ritlug.github.io.svg?style=shield&circle-token=750a96e7410a2300c741356993092a6d066d7ee6)](https://circleci.com/gh/patkub/ritlug.github.io)
+
 RITlug's current website.
 
 ## Updating Meeting Times/Places


### PR DESCRIPTION
We can test that Jekyll successfully builds the site using CircleCI. This installs dependencies (Jekyll) with bundle, caches them for future builds, and then runs `bundle exec jekyll build` to build the site. This whole process runs in less than 30 seconds! See https://github.com/RITlug/ritlug.github.io/pull/84#issuecomment-321439074 for more information.

Once this PR is merged, create a circleci build status token. Use the circle-token for the [status badge](https://circleci.com/docs/1.0/status-badges/) shield in the README to display the build status of this repo instead of my forked branch.