### PR TITLE
Codeclimate code analysis

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,3 @@
+engines:
+  css-lint: true
+  fixme: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,5 @@
 engines:
-  css-lint: true
-  fixme: true
+  css-lint:
+    enabled: true
+  fixme:
+    enabled: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ritlug.github.io
 
 [![CircleCI](https://circleci.com/gh/RITlug/ritlug.github.io.svg?style=svg&circle-token=b80b9ee3852aa0b52f578b434c6224971fc73d97)](https://circleci.com/gh/RITlug/ritlug.github.io)
-[![Code Climate](https://codeclimate.com/github/patkub/ritlug.github.io/badges/gpa.svg)](https://codeclimate.com/github/patkub/ritlug.github.io)
-[![Issue Count](https://codeclimate.com/github/patkub/ritlug.github.io/badges/issue_count.svg)](https://codeclimate.com/github/patkub/ritlug.github.io)
+[![Code Climate](https://codeclimate.com/github/RITlug/ritlug.github.io/badges/gpa.svg)](https://codeclimate.com/github/RITlug/ritlug.github.io)
+[![Issue Count](https://codeclimate.com/github/RITlug/ritlug.github.io/badges/issue_count.svg)](https://codeclimate.com/github/RITlug/ritlug.github.io)
 
 RITlug's current website.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ritlug.github.io
 
 [![CircleCI](https://circleci.com/gh/RITlug/ritlug.github.io.svg?style=svg&circle-token=b80b9ee3852aa0b52f578b434c6224971fc73d97)](https://circleci.com/gh/RITlug/ritlug.github.io)
+[![Code Climate](https://codeclimate.com/github/patkub/ritlug.github.io/badges/gpa.svg)](https://codeclimate.com/github/patkub/ritlug.github.io)
+[![Issue Count](https://codeclimate.com/github/patkub/ritlug.github.io/badges/issue_count.svg)](https://codeclimate.com/github/patkub/ritlug.github.io)
 
 RITlug's current website.
 


### PR DESCRIPTION
Codeclimate is a tool that integrates with github and provides code analysis. It shows lines of code, churn, issues, etc. This is setup to show css lint issues and TODO comments. To enable, add this repo in codeclimate from the [dashboad](https://codeclimate.com/oss/dashboard) after merging this PR. Here is what this looks like:
https://codeclimate.com/github/patkub/ritlug.github.io

