### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Table of Contents
 * [Updating meeting times / places](#updating-meeting-times--places)
-* [Javascript and CSS patches](#javascript-and-css-patches)
+* [Patches](#patches)
 * [Development and Testing](#developing-and-testing)
 
 
@@ -18,9 +18,7 @@ the meeting time and place are referenced so that they can be updated in
 one place.
 
 
-## Javascript and CSS patches
-
-There's a couple of patches to the Javascript and CSS. They are:
+## Patches
 
 ### Header Height
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,6 @@ shrank it. If you want to change the header height, do the following:
 2. Search for `.mdl-demo .mdl-layout__header-row {`.
 3. Find and change the height. Default is 64px. We're currently using 25px.
 
-### Make header links open pages
-
-The default Javascript in MDL <1.0.6 expects the links at the top of the page
-to open different tabs. This website is built with pages, not tabs. There&apos;s
-a patch in the event handler that enables opening separate pages. Modern
-versions of MDL do not require this as they already have the patch implemented.
-
 
 ## Developing and testing
 

--- a/README.md
+++ b/README.md
@@ -44,18 +44,18 @@ versions of MDL do not require this as they already have the patch implemented.
 
 ### Setup
 
-1) Install Ruby:
+First, install Ruby:
 `sh
 sudo (apt-get install|pacman -S|...) ruby
 `
 
-2) Install bundler using gem.
+Then, install bundler using gem.
 
 `sh
 sudo gem install bundler
 `
 
-3) Install dependencies with bundler.
+Lastly, install dependencies with bundler.
 
 `sh
 bundle install

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ one place.
 ### Header Height
 
 The default header in Material Design Lite is too large on desktop so we've
-shrank it. If you want to change the header height, do the following:
+shrunk it. If you want to change the header height, do the following:
 
 1. Open `css/styles.css`
 2. Search for `.mdl-demo .mdl-layout__header-row {`.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ bundle install
 
 ### Start the development server
 
-This command serves the site at http://localhost:4000
+This command serves the site at http://localhost:4000.
 
 ```sh
 jekyll serve

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/RITlug/ritlug.github.io.svg?style=svg&circle-token=b80b9ee3852aa0b52f578b434c6224971fc73d97)](https://circleci.com/gh/RITlug/ritlug.github.io)
 
-RITlug's current website.
+> RITlug's current website.
 
 ### Table of Contents
 * [Updating meeting times / places](#updating-meeting-times--places)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ versions of MDL do not require this as they already have the patch implemented.
 ### Setup
 
 First, install Ruby:
+
 `sh
 sudo (apt-get install|pacman -S|...) ruby
 `

--- a/README.md
+++ b/README.md
@@ -46,29 +46,29 @@ versions of MDL do not require this as they already have the patch implemented.
 
 First, install Ruby:
 
-`sh
+```sh
 sudo (apt-get install|pacman -S|...) ruby
-`
+```
 
 Then, install bundler using gem.
 
-`sh
+```sh
 sudo gem install bundler
-`
+```
 
 Lastly, install dependencies with bundler.
 
-`sh
+```sh
 bundle install
-`
+```
 
 ### Start the development server
 
 This command serves the site at http://localhost:4000
 
-`sh
+```sh
 jekyll serve
-`
+```
 
 See [the runbook](https://github.com/RITlug/runbook/blob/master/the-website.md)
 for more details.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 RITlug's current website.
 
+### Table of Contents
+* [Updating meeting times / places](#updating-meeting-times--places)
+* [Javascript and CSS patches](#javascript-and-css-patches)
+* [Development and Testing](#developing-and-testing)
+
 
 ## Updating meeting times / places
 
@@ -36,16 +41,33 @@ versions of MDL do not require this as they already have the patch implemented.
 
 ## Developing and testing
 
-Test the site by installing Jekyll:
 
-    sudo (apt-get install|pacman -S|...) ruby
-    sudo gem install jekyll
+### Setup
 
-Then running…
+1) Install Ruby:
+`sh
+sudo (apt-get install|pacman -S|...) ruby
+`
 
-    jekyll serve
+2) Install bundler using gem.
 
-…in the cloned repository. The site will be available on localhost:4000.
+`sh
+sudo gem install bundler
+`
+
+3) Install dependencies with bundler.
+
+`sh
+bundle install
+`
+
+### Start the development server
+
+This command serves the site at http://localhost:4000
+
+`sh
+jekyll serve
+`
 
 See [the runbook](https://github.com/RITlug/runbook/blob/master/the-website.md)
 for more details.


### PR DESCRIPTION
- Include a table of contents
- Remove old info about JavaScript tabs patch
- Use Ruby bundler to setup local development / testing.

`bundle install` will install jekyll
