### PR TITLE
Configurable footer links

### DIFF
--- a/_data/footer/feeds.yml
+++ b/_data/footer/feeds.yml
@@ -1,0 +1,5 @@
+- name: Announcements
+  link: /feeds/latest.xml
+  
+- name: Talks
+  link: /feeds/talks.xml

--- a/_data/footer/linux_resources.yml
+++ b/_data/footer/linux_resources.yml
@@ -1,0 +1,14 @@
+- name: ArchWiki
+  link: http://wiki.archlinux.org
+  
+- name: Kernel Newbies
+  link: http://kernelnewbies.org
+  
+- name: Linux Subreddit
+  link: http://reddit.com/r/linux
+  
+- name: DistroWatch
+  link: http://distrowatch.org
+
+- name: RIT Mirror
+  link: http://mirrors.rit.edu

--- a/_data/footer/rit.yml
+++ b/_data/footer/rit.yml
@@ -1,0 +1,8 @@
+- name: www.rit.edu
+  link: http://www.rit.edu
+  
+- name: RIT School of Computing
+  link: http://www.rit.edu/gccis
+  
+- name: RIT Club Page
+  link: http://thelink.rit.edu/organization/Linux

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -41,6 +41,18 @@
               {% endfor %}
             </ul>
           </div>
+          <div class="mdl-mega-footer--drop-down-section">
+            <input class="mdl-mega-footer--heading-checkbox" type="checkbox" checked>
+            <h1 class="mdl-mega-footer--heading">Feeds</h1>
+            <ul class="mdl-mega-footer--link-list">
+              <!-- feeds -->
+              {% for item in site.data.footer.feeds %}
+                <li>
+                  <a href="{{ item.link }}">{{ item.name }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
         </div>
         <div class="mdl-mega-footer--bottom-section">
           <div class="mdl-logo">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,10 +5,16 @@
             <input class="mdl-mega-footer--heading-checkbox" type="checkbox" checked>
             <h1 class="mdl-mega-footer--heading">Navigate</h1>
             <ul class="mdl-mega-footer--link-list">
-              <li><a href="/about.html">About</a></li>
+              {% for tab in site.data.tabs %}
+                <li>
+                  <a href="{{ tab.link }}">{{ tab.name }}</a>
+                </li>
+              {% endfor %}
+              
+              <!-- <li><a href="/about.html">About</a></li>
               <li><a href="/talks">Talks</a></li>
               <li><a href="/get-involved.html">Get Involved</a></li>
-              <li><a href="/announcements">Announcements</a></li>
+              <li><a href="/announcements">Announcements</a></li> -->
             </ul>
           </div>
           <div class="mdl-mega-footer--drop-down-section">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,6 +21,7 @@
             <input class="mdl-mega-footer--heading-checkbox" type="checkbox" checked>
             <h1 class="mdl-mega-footer--heading">RIT</h1>
             <ul class="mdl-mega-footer--link-list">
+              <!-- RIT footer links -->
               {% for item in site.data.footer.rit %}
                 <li>
                   <a href="{{ item.link }}">{{ item.name }}</a>
@@ -32,11 +33,12 @@
             <input class="mdl-mega-footer--heading-checkbox" type="checkbox" checked>
             <h1 class="mdl-mega-footer--heading">Linux Resources</h1>
             <ul class="mdl-mega-footer--link-list">
-              <li><a href="http://wiki.archlinux.org">ArchWiki</a></li>
-              <li><a href="http://kernelnewbies.org">Kernel Newbies</a></li>
-              <li><a href="http://reddit.com/r/linux">Linux Subreddit</a></li>
-              <li><a href="http://distrowatch.org">DistroWatch</a></li>
-              <li><a href="http://mirrors.rit.edu">RIT Mirror</a></li>
+              <!-- linux resources -->
+              {% for item in site.data.footer.linux_resources %}
+                <li>
+                  <a href="{{ item.link }}">{{ item.name }}</a>
+                </li>
+              {% endfor %}
             </ul>
           </div>
         </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,11 +10,6 @@
                   <a href="{{ tab.link }}">{{ tab.name }}</a>
                 </li>
               {% endfor %}
-              
-              <!-- <li><a href="/about.html">About</a></li>
-              <li><a href="/talks">Talks</a></li>
-              <li><a href="/get-involved.html">Get Involved</a></li>
-              <li><a href="/announcements">Announcements</a></li> -->
             </ul>
           </div>
           <div class="mdl-mega-footer--drop-down-section">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,12 @@
             <input class="mdl-mega-footer--heading-checkbox" type="checkbox" checked>
             <h1 class="mdl-mega-footer--heading">Navigate</h1>
             <ul class="mdl-mega-footer--link-list">
+              <!-- site navigation tabs -->
               {% for tab in site.data.tabs %}
+                <!-- ignore "The Link" which is in the RIT section -->
+                {% if tab.name == 'The Link' %}
+                  {% continue %}
+                {% endif %}
                 <li>
                   <a href="{{ tab.link }}">{{ tab.name }}</a>
                 </li>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,9 +21,11 @@
             <input class="mdl-mega-footer--heading-checkbox" type="checkbox" checked>
             <h1 class="mdl-mega-footer--heading">RIT</h1>
             <ul class="mdl-mega-footer--link-list">
-              <li><a href="http://www.rit.edu">www.rit.edu</a></li>
-              <li><a href="http://www.rit.edu/gccis">RIT School of Computing</a></li>
-              <li><a href="http://thelink.rit.edu/organization/Linux">RIT Club Page</a></li>
+              {% for item in site.data.footer.rit %}
+                <li>
+                  <a href="{{ item.link }}">{{ item.name }}</a>
+                </li>
+              {% endfor %}
             </ul>
           </div>
           <div class="mdl-mega-footer--drop-down-section">


### PR DESCRIPTION
- Made footer section links easily configurable using Jekyll yaml data files.
- Changed the **Navigate** section footer links to be the same as the page navigation tabs, but excluded **The Link** tab since it is under the RIT footer section as **RIT Club Page**.
- Added feed links (announcements and talks) to the footer.

New **Navigate** footer section list:
- Home
- Announcements
- Talks
- About
- Get Involved

Old list:
- About
- Talks
- Get Involved
- Announcements
