### PR TITLE
Add generic meeting announcement template to speed up announcements

### DIFF
--- a/announcements/meeting-announcement-template.md
+++ b/announcements/meeting-announcement-template.md
@@ -1,0 +1,78 @@
+<!--
+
+    This file is a template for writing meeting announcements each week. Copy
+    this template into the `_posts` directory with a correct file name and edit
+    the details as needed.
+
+    NOTE: The file name should follow this naming convention:
+
+        YYYY-MM-DD-week-XX-meeting.md
+
+    Where YYYY is year, MM is month, DD is day, and XX is what week of the
+    semester the announcement is for. The date MUST be formatted correctly since
+    the site uses that as a timestamp!
+
+ -->
+
+
+---
+author: Your Name
+title: "Topic title - Month day, time"
+layout: post
+date: YYYY-MM-DD
+---
+
+Hi RITlug!
+
+Welcome to Week XX! RITlug is back again this week – here's what we're covering
+this week:
+
+
+### Presentation / topic title goes here
+
+Join RITlug on **Friday, month, day** at **time in GOL-2650** (large DB lab)
+for…
+
+<!--
+
+    Presentation / topic abstract goes here. Whatever the topic is, add 2-3
+    sentences to excite people and build interest. This is 90% of the work of
+    this email.
+
+ -->
+
+
+### tl;dr details
+
+* **Day**: Friday, month day, 2017
+* **Time**: 4:00pm - 6:00pm
+* **Where**: GOL-2650 (large DB lab, 2nd floor of GCCIS)
+* **What to bring**: <!-- Optional, remove line if not needed -->
+
+
+### Come hang out with us!
+
+RITlug is on Slack. Keep in touch with our community or get involved with a
+project on Slack. Anyone with an RIT email can register
+[here](https://rit-lug.slack.com/signup "Join the RITlug Slack"). Be sure to say
+hello when you join!
+
+* [CampusGroups](https://campusgroups.rit.edu/student_community?club_id=16071 "
+RITlug on CampusGroups")
+* [Website](http://ritlug.com "RIT Linux Users Group website")
+* [Slack](https://rit-lug.slack.com/signup "Join the RITlug Slack")
+
+If you join, make sure to say hello!
+
+The **mailing list** is the most important way to stay informed about RITlug.
+Make sure you're a member of our [mailing
+list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug  mailing
+list - Google Groups").
+
+**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+
+We hope to see you this week!
+
+Cheers,
+- Your Name (Slack / IRC username)
+


### PR DESCRIPTION
This adds a generic meeting template file to speed up the process of creating weekly meeting announcements. Some guidelines on how to do this is also included as a comment at the top of the file.

The hope is this will remove the bottleneck on writing the email announcement every week by making it easier to prep.

## 3/5 of eboard must approve before merging