### PR TITLE
Add special announcement for eboard nominations

### DIFF
--- a/announcements/_posts/2018-03-30-week-10-nominations.md
+++ b/announcements/_posts/2018-03-30-week-10-nominations.md
@@ -1,0 +1,59 @@
+---
+author: Justin W. Flory
+title: "2018-2019 Eboard nominations open"
+layout: post
+date: 2018-03-30
+---
+
+Hi RITlug!
+
+This is the Friday of Week 10, which means nominations for the RITlug executive
+board (eboard) are now open.
+
+
+### Nominations now open
+
+Nominations open today and close at the end of Week 11 (i.e. Sunday, April 8,
+2018 at 11:59 PM EDT). Voting begins immediately after.
+
+Running for eboard is a great way to help shape the future of RITlug. You will
+work with other members to help run the club, work with projects inside RITlug,
+and organize small events in the community.
+
+The executive board of any student organization is a great way to demonstrate
+leadership and teamwork on your resume too. Eboard members need to be organized
+and efficient. They must also demonstrate good communication skills with others
+on the eboard and with the club community. It can be a great conversation
+starter for a future job or co-op interview.
+
+**Please cast all nominations (for someone else or a self-nomination) by Sunday,
+April 8, 2018 at 11:59 PM EDT.** Votes are collected in this form:
+
+_**[Cast a RITlug eboard nomination](https://goo.gl/forms/2KYZrqREEva1xEyj2)**_
+
+If nominating someone else, please ask them for their permission first.
+
+
+### tl;dr details
+
+* **What**: RITlug eboard nominations open
+* **When**: From now until Sunday, April 8, 2018 at 11:59 PM EDT
+* **How**: Cast nomination in the above form
+
+
+### Questions?
+
+If you have questions about what it means to be on RITlug executive board or
+want to know more information, please reach out to me on Slack, Telegram, or IRC
+(or ask me during the general meeting).
+
+You can also read more about how RITlug is managed and run in our
+[Runbook](http://runbook.ritlug.com), although it is not yet finished.
+
+Looking forward to the election in Week 12. See you in RITlug today!
+
+As always, keep the FOSS flag high.
+
+Cheers,
+- Justin W. Flory (jwf / jflory)
+


### PR DESCRIPTION
This is a special email to announce eboard nominations are now open, per election policy defined in the Runbook. We can get this out in time for the meeting and start a discussion during the meeting about it.