### PR TITLE
Add announcement for @harlanhaskins's Swift talk on April 6, 2018

### DIFF
--- a/announcements/_posts/2018-04-02-week-11-meeting.md
+++ b/announcements/_posts/2018-04-02-week-11-meeting.md
@@ -1,0 +1,60 @@
+--
+author: Justin W. Flory
+title: "Introduction to Swift - April 6, 4pm"
+layout: post
+date: 2018-04-02
+---
+
+Hi RITlug!
+
+Welcome to Week 11! RITlug is back again this week – here's what we're covering
+this week:
+
+
+### Introduction to Swift programming language
+
+Join RITlug on **Friday, April 8, 2018** at **4pm in GOL-2620** (medium DB lab)
+for an introduction to the Swift programming language and community by Harlan
+Haskins.
+
+Swift is a landmark open-source project with hundreds of contributors and many,
+many times more users. The Swift community is full of intelligent, insightful
+users ready to contribute their voice to the project. Join Harlan and Robert,
+two former interns on the Swift team, on a journey from checking out source to
+closing a Swift bug report, live! Along the way, learn about core concepts,
+tips, and best practices for effectively making your mark on the Swift project.
+
+
+### tl;dr details
+
+* **Day**: Friday, April 6, 2018
+* **Time**: 4:00pm - 6:00pm
+* **Where**: GOL-2620 (medium DB lab, 2nd floor of GCCIS)
+
+
+### Come hang out with us!
+
+RITlug is on Slack. Keep in touch with our community or get involved with a
+project on Slack. Anyone with an RIT email can register
+[here](https://rit-lug.slack.com/signup "Join the RITlug Slack"). Be sure to say
+hello when you join!
+
+* [CampusGroups](https://campusgroups.rit.edu/student_community?club_id=16071 "
+RITlug on CampusGroups")
+* [Website](http://ritlug.com "RIT Linux Users Group website")
+* [Slack](https://rit-lug.slack.com/signup "Join the RITlug Slack")
+
+If you join, make sure to say hello!
+
+The **mailing list** is the most important way to stay informed about RITlug.
+Make sure you're a member of our [mailing
+list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing
+list - Google Groups").
+
+**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+
+We hope to see you this week! As always, keep the FOSS flag high.
+
+Cheers,
+- Justin W. Flory (jwf / jflory)
+


### PR DESCRIPTION
# DO NOT MERGE UNTIL MONDAY, APRIL 4

This pull request adds next week's meeting announcement for @harlanhaskins's talk on the Swift programming language and community. We can merge on Monday morning and get it propagated early in the week.

@RITlug/eboard, could someone add a review on this in the meanwhile? :eyes: 