### PR TITLE
Add Week 13 weekly announcement (How to build a RPM package)

### DIFF
--- a/announcements/_posts/2018-04-16-week-13-meeting.md
+++ b/announcements/_posts/2018-04-16-week-13-meeting.md
@@ -1,0 +1,58 @@
+---
+author: Justin W. Flory
+title: "How to build an RPM package - April 20, 4pm"
+layout: post
+date: 2018-04-16
+---
+
+Hi RITlug!
+
+Welcome to Week 13! RITlug is back again this week – here's what we're covering
+this week:
+
+
+### How to build an RPM package
+
+Join RITlug on **Friday, April 20** at **4:00pm in GOL-2620** (medium DB lab)
+for _How to build an RPM package_ from Tim Zabel and Aidan Kahrs!
+
+Ever found a great piece of software, but it isn't packaged in your
+distribution? Come learn how to package your own application! We will go over
+the process of creating an RPM package on Fedora from start to finish, including
+a live demo!
+
+
+### tl;dr details
+
+* **Day**: Friday, April 20th, 2018
+* **Time**: 4:00pm - 6:00pm
+* **Where**: GOL-2620 (large DB lab, 2nd floor of GCCIS)
+* **What to bring**: Laptop (with Fedora or a Fedora virtual machine)
+
+
+### Come hang out with us!
+
+RITlug is on Slack. Keep in touch with our community or get involved with a
+project on Slack. Anyone with an RIT email can register
+[here](https://rit-lug.slack.com/signup "Join the RITlug Slack"). Be sure to say
+hello when you join!
+
+* [CampusGroups](https://campusgroups.rit.edu/student_community?club_id=16071 "
+RITlug on CampusGroups")
+* [Website](http://ritlug.com "RIT Linux Users Group website")
+* [Slack](https://rit-lug.slack.com/signup "Join the RITlug Slack")
+
+If you join, make sure to say hello!
+
+The **mailing list** is the most important way to stay informed about RITlug.
+Make sure you're a member of our [mailing
+list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing
+list - Google Groups").
+
+**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+
+We hope to see you this week! As always, keep the FOSS flag high.
+
+Cheers,
+- Justin W. Flory (jwf / jflory)
+


### PR DESCRIPTION
# Do not merge until Monday, April 16

This PR adds the Week 13 email announcement on _How to build a RPM package_ by @Tjzabel and @axk4545.

@RITlug/eboard, please take a quick review of the email draft and leave an approval.

I would also like either @axk4545 or @Tjzabel to add an approved review before merging, since this is their talk.