### PR TITLE
Events and calendar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: RIT Linux Users Group
 title-abbrev: RITlug
 
-email: ritlug@rit.edu
+email: eboard@ritlug.com
 description: > # this means to ignore newlines until "baseurl:"
   Official site of the RIT Linux Users Group (RITlug). Find all
   our talks and announcements here.
@@ -12,6 +12,9 @@ url: 'https://ritlug.com'
 markdown: kramdown
 permalink: pretty # no .html extension needed/wanted
 excerpt_separator: <!--more-->
+
+# Allow events in the future (for calendar feed)
+future: true
 
 # These allow RITlug's schedule to be updated site-wide from one
 # location. They will appear in pages as they are typed, so it

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Redirecting... | {{site.title-abbrev}}</title>
+    <meta http-equiv="refresh" content="0; url={{page.redirect}}" />
+</head>
+<body>
+<a href="{{page.redirect}}">Should be redirected, click here if you see this message.</a>
+</body>
+</html>

--- a/feeds/calendar.ics
+++ b/feeds/calendar.ics
@@ -1,0 +1,27 @@
+---
+layout: none
+---
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//{{site.title}}//{{site.url}}//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH{% for post in site.posts %}{% if post.categories.last == "meetings-meetups" or post.categories.first == "events" or post.categories.first == "talks" %}
+BEGIN:VEVENT
+UID:{{site.url}}{{site.baseurl}}{{post.url}}
+DTSTAMP:{{ post.date | date: "%Y%m%dT000000Z" }}{% if post.date-start %}
+DTSTART;TZID=America/New_York:{{ post.date-start | date: "%Y%m%dT%H%M00" }}{% else %}
+DTSTART:{{ post.date | date: "%Y%m%d" }}{% endif %}{% if post.date-end %}
+DTEND;TZID=America/New_York:{{ post.date-end | date: "%Y%m%dT%H%M00" }}{% else %}
+DTEND:{{ post.date | date: "%Y%m%d" }}{% endif %}
+ORGANIZER;CN="{{site.title}}":MAILTO:{{site.email}}
+SUMMARY:{{post.title}}
+DESCRIPTION:{{post.excerpt | strip_html | newline_to_br | replace: "<br />", " " | strip_newlines | strip}}
+CLASS:PUBLIC{% if post.location %}
+LOCATION:{{post.location}}{% endif %}{% if post.redirect %}
+URL:{{post.redirect}}{% elsif post.categories.last != "meetings-meetups" %}
+URL:{{site.url}}{{site.baseurl}}{{post.url}}{% else %}
+URL:{{site.url}}{{site.baseurl}}/get-involved{% endif %}{% if post.categories.last == "meetings-meetups" %}
+CATEGORIES:{{site.title-abbrev}},{{site.title}},{{post.categories.last | upcase}}{% else %}
+CATEGORIES:{{site.title-abbrev}},{{site.title}},{{post.categories.first | upcase}}{% endif %}
+END:VEVENT{% endif %}{% endfor %}
+END:VCALENDAR

--- a/get-involved.md
+++ b/get-involved.md
@@ -3,9 +3,14 @@ layout: page
 title: Get Involved
 ---
 
-Meetings are open to anyone interested, new members and old. RITlug meets on every {{ site.ritlug-day }}, {{ site.ritlug-time }} in {{ site.ritlug-place }}. If you can't make the whole time, that's fine! Meetings typically have a presentation first, then we open the floor to discussion and technical help. Interested? Just show up!
+Meetings are open to anyone interested, new members and old.
+RITlug meets on every {{ site.ritlug-day }}, {{ site.ritlug-time }} in {{ site.ritlug-place }}.
+If you can't make the whole time, that's fine!
+Meetings typically have a presentation first, then we open the floor to discussion and technical help.
+We also hold "Project Collaboration" sessions where you can come and work on projects, homework, or just hang out.
+**_Interested? Just show up!_**
 
-Looking for more information? Email us at ritlug@rit.edu.
+Looking for more information? Email us at {{ site.email }}.
 
 ##### Stay Updated
 * [RIT CampusGroups](https://campusgroups.rit.edu/student_community?club_id=16071) (Join this one if you have an RIT account. You'll get the other feeds by email for free!)

--- a/meetings-meetups/_posts/2018-10-27-project-collab.md
+++ b/meetings-meetups/_posts/2018-10-27-project-collab.md
@@ -1,0 +1,9 @@
+---
+layout: redirect
+redirect: /get-involved
+date-start: "2018-10-27 13:00"
+date-end: "2018-10-27 15:00"
+location: "Java Wally's"
+title: "RITlug Project Collaboration"
+---
+Come hang out! This is also a good time to work on Hacktoberfest PRs


### PR DESCRIPTION
This PR covers several things:

1. Adds a redirect layout
  * Fixes #172 
2. Creates a new "Meetings & Meetups" section which is intended as a data directory and not for actual pages (although it technically could be used for pages)
3. Creates a calendar file at `/feeds/calendar.ics` which pulls from talks, events, & meetups/meetings
4. Adds a sample page for this week's project collab, which redirects to the "Get Involved" page
  * Fixes #171 
5. Cleans up the "Get Involved" page & adds project collab as a thing
6. Updates config to eboard email & to allow posts in the future (used for calendar feed)

Normally I'd split this across a few PRs but they ended up happening as I needed them.
Also, the calendar.ics file looks abominable, but due to the quirks of how Jekyll generates, "pretty" code would break the spec and caused the validator I was testing with to really flip out.