### PR TITLE
Remove Facebook and Reddit from  site (they are not monitored)

### DIFF
--- a/get-involved.md
+++ b/get-involved.md
@@ -12,25 +12,28 @@ We also hold "Project Collaboration" sessions where you can come and work on pro
 
 Looking for more information? Email us at {{ site.email }}.
 
+
 ##### Stay Updated
+
 * [RIT CampusGroups](https://campusgroups.rit.edu/student_community?club_id=16071) (Join this one if you have an RIT account. You'll get the other feeds by email for free!)
 * [Announcement feed](/feeds/latest.xml) (RSS feed for RITlug announcements)
 * [Public announcement mailing list](https://groups.google.com/d/forum/ritlug-announce) (Public mailing list for RITlug announcements)
 * [RITlug talks feed](/feeds/talks.xml) (RSS feed for RITlug talks)
 
 ##### Discussion
+
 * Come to meetings!
 * [Slack (for RIT Students)](https://rit-lug.slack.com/)
 * [Telegram](https://telegram.me/ritlugclub)
 * [IRC Channel](ircs://irc.freenode.net/ritlug) ([webchat](https://webchat.freenode.net/?channels=ritlug))
-* [Facebook page](https://facebook.com/groups/RITlug) (restricted to past and present RIT students and staff only, sorry!)
 * [Twitter](https://twitter.com/RITlug)
-* [Reddit](https://www.reddit.com/r/RITlug)
 
 ##### Open Source Code and Governance
+
 * [Github Organization](https://github.com/RITlug) (club governing documents, website, and projects)
 
 ##### Events
+
 * Weekly Meetings on {{ site.ritlug-day }}s, {{ site.ritlug-time }}
 * RIT Club Fairs
 * Occasional [FOSS@MAGIC](http://foss.rit.edu) Events


### PR DESCRIPTION
We archived our Facebook and I actually forgot we had a subreddit? Let's not link these things on the website since they are not actively monitored.