### PR TITLE
announcements: Fix formatting of announcement metadata

### DIFF
--- a/announcements/_posts/2019-04-12-w12-customization.md
+++ b/announcements/_posts/2019-04-12-w12-customization.md
@@ -1,8 +1,8 @@
---
+---
 author: Jeffery Russell (@Jrtechs)
 title: "Week #12: Customization Galore"
 layout: post-event
-date-start: "2019-04-12 16:00"                               
+date-start: "2019-04-12 16:00"
 date-end: "2019-04-12 18:00"
 location: "GOL-2650 (Lg. DB Lab)"
 ---


### PR DESCRIPTION
The last announcement was missing a dash and threw off the formatting. This is a quick fix for the formatting.