### PR TITLE
Improve footer link contrast

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -79,10 +79,10 @@ footer li {
     list-style: none;
 }
 footer a {
-    color: white;
+    color: #B3B3FF;
     text-decoration: underline;
 }
 footer a:hover {
-    color: white;
+    color: #B3B3FF;
     text-decoration: none;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -79,5 +79,10 @@ footer li {
     list-style: none;
 }
 footer a {
-    color: #17a2b8;
+    color: white;
+    text-decoration: underline;
+}
+footer a:hover {
+    color: white;
+    text-decoration: none;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -78,3 +78,6 @@ footer ul {
 footer li {
     list-style: none;
 }
+footer a {
+    color: #17a2b8;
+}


### PR DESCRIPTION
The blue on gray is a little hard to see in the footer in some circumstances, like if you use f.lux or redshift. This lightens it up a hair to make it a little bit better (but not so much as to totally change the look).

# Before:
![image](https://user-images.githubusercontent.com/2584772/66620041-1a064980-ebad-11e9-9d7b-3bbd2254e5a6.png)

# After:
![image](https://user-images.githubusercontent.com/2584772/66620067-28546580-ebad-11e9-96ba-5c074f27f3cd.png)
