### PR TITLE
Remove incorrect general meeting place & time.

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ title: Home
         <p class="lead">We are a student-led organization to  contribute to and engage students in Linux &amp; open source.</p>
         <hr class="lead-4" />
         <p>Work on projects and discuss interesting topics in the Linux &amp; open source communities.</p>
-        <p>Weekly meetings every {{ site.ritlug-day }}, {{ site.ritlug-time }} in {{ site.ritlug-place }}, Fall &amp; Spring.</p>
+        <p>Weekly meetings every {{ site.ritlug-day }}, from {{ site.ritlug-time }}.</p>
     </div>
 </section>
 


### PR DESCRIPTION
With us meeting remotely this semester, I decided not to add any specific meeting place, but rather just state the time on our homepage.