### PR TITLE
Discord linking does not work on sidebar.

### DIFF
--- a/announcements/_posts/2020-10-01-w07-intro-to-git.md
+++ b/announcements/_posts/2020-10-01-w07-intro-to-git.md
@@ -4,7 +4,7 @@ title: "Week #7: Intro to Git"
 layout: post-event
 date-start: "2020-10-01 16:30"
 date-end: "2020-10-01 18:00"
-location: "[Discord](https://discord.gg/xev2W62)"
+location: "Discord"
 ---
 
 Hey RITlug,


### PR DESCRIPTION
Markdown hyperlinks don't work on the side bar, so I am removing it. We need to figure out the best way to share the Discord link on our site. 