### PR TITLE
Add link to Discord to every announcement post.

### DIFF
--- a/_layouts/post-event.html
+++ b/_layouts/post-event.html
@@ -30,6 +30,7 @@ layout: default
           <h3>Keep up to date:</h3>
         </div>
         <div class="list-group list-group-flush">
+          <a href="https://discord.gg/xev2W62" class="list-group-item list-group-item-action">Discord</a>
           <a href="https://rit-lug.slack.com/" class="list-group-item list-group-item-action">Slack (needs <code>@rit.edu</code> email)</a>
           <a href="https://campusgroups.rit.edu/student_community?club_id=16071" class="list-group-item list-group-item-action">CampusGroups</a>
           <a href="https://webchat.freenode.net/?channels=ritlug" class="list-group-item list-group-item-action"><code>#ritlug</code> on IRC</a>


### PR DESCRIPTION
A good compromise to adding our Discord link to the front page of https://ritlug.com is to add it to each announcement we send out. I think this can satisfy our comments about not needing a `@rit.edu` domain email to get access to our discord. 


Closes #284.