### PR TITLE
Deduplicate some social media links to make them easy to update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,6 @@ ritlug-day: Friday
 
 # this allows social links to also be easily updated
 social:
-  irc: https://webchat.freenode.net/?channels=ritlug
+  irc: https://web.libera.chat/gamja/?channels=%23rit-lug
   mailinglist: https://groups.google.com/forum/#!forum/ritlug-announce
   discord: https://discord.gg/xev2W62

--- a/_config.yml
+++ b/_config.yml
@@ -27,3 +27,4 @@ ritlug-day: Friday
 # this allows social links to also be easily updated
 social:
   irc: https://webchat.freenode.net/?channels=ritlug
+  mailinglist: https://groups.google.com/forum/#!forum/ritlug-announce

--- a/_config.yml
+++ b/_config.yml
@@ -23,3 +23,7 @@ future: true
 ritlug-time: 4:30PM - 6:00PM
 ritlug-place: GOL/70-2620 (Medium DB Lab)
 ritlug-day: Friday
+
+# this allows social links to also be easily updated
+social:
+  irc: https://webchat.freenode.net/?channels=ritlug

--- a/_config.yml
+++ b/_config.yml
@@ -28,3 +28,4 @@ ritlug-day: Friday
 social:
   irc: https://webchat.freenode.net/?channels=ritlug
   mailinglist: https://groups.google.com/forum/#!forum/ritlug-announce
+  discord: https://discord.gg/xev2W62

--- a/_layouts/post-event.html
+++ b/_layouts/post-event.html
@@ -30,7 +30,7 @@ layout: default
           <h3>Keep up to date:</h3>
         </div>
         <div class="list-group list-group-flush">
-          <a href="https://discord.gg/xev2W62" class="list-group-item list-group-item-action">Discord</a>
+          <a href="{{site.social.discord}}" class="list-group-item list-group-item-action">Discord</a>
           <a href="https://rit-lug.slack.com/" class="list-group-item list-group-item-action">Slack (needs <code>@rit.edu</code> email)</a>
           <a href="https://campusgroups.rit.edu/student_community?club_id=16071" class="list-group-item list-group-item-action">CampusGroups</a>
           <a href="{{site.social.irc}}" class="list-group-item list-group-item-action"><code>#ritlug</code> on IRC</a>

--- a/_layouts/post-event.html
+++ b/_layouts/post-event.html
@@ -33,7 +33,7 @@ layout: default
           <a href="https://discord.gg/xev2W62" class="list-group-item list-group-item-action">Discord</a>
           <a href="https://rit-lug.slack.com/" class="list-group-item list-group-item-action">Slack (needs <code>@rit.edu</code> email)</a>
           <a href="https://campusgroups.rit.edu/student_community?club_id=16071" class="list-group-item list-group-item-action">CampusGroups</a>
-          <a href="https://webchat.freenode.net/?channels=ritlug" class="list-group-item list-group-item-action"><code>#ritlug</code> on IRC</a>
+          <a href="{{site.social.irc}}" class="list-group-item list-group-item-action"><code>#ritlug</code> on IRC</a>
           <a href="https://twitter.com/RITlug" class="list-group-item list-group-item-action">Twitter</a>
         </div>
       </div>

--- a/announcements/_posts/2016-05-04-week-14-letsencrypt.md
+++ b/announcements/_posts/2016-05-04-week-14-letsencrypt.md
@@ -12,7 +12,7 @@ As of this week, we also have a few more ways that you can get involved with RIT
 
 * Facebook: https://www.facebook.com/groups/RITLUG/
 * Telegram: https://telegram.me/joinchat/BVxlKADKpMbhHtgxKkdjSQ
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 
 This week's topic covers a hot topic in the system administration world (and even more than just sysadmin): LetsEncrypt! If you haven't heard about LetsEncrypt, it is free and open source software that runs as a free Certificate Authority. What does that mean in English? It lets anyone get free SSL certificates for your domains. In our talk, we're going to introduce it, how it works, and most importantly, how to get your own certificate!
 

--- a/announcements/_posts/2016-05-12-week-15-finals-finals-finals.md
+++ b/announcements/_posts/2016-05-12-week-15-finals-finals-finals.md
@@ -10,7 +10,7 @@ As a friendly reminder, we also have a few more ways that you can get involved w
 
 * Facebook: https://www.facebook.com/groups/RITLUG/
 * Telegram: https://telegram.me/joinchat/BVxlKADKpMbhHtgxKkdjSQ
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 
 With this being the last week before finals, we've decided this week's meeting will be an open floor for the full two hours. Lightning talks are also welcome! If you have a "hot new thing" you want to present on in five minutes or less, there's never been a better time for it. Otherwise, we will be open to discussion and working on a variety of mixed topics in the meeting.
 

--- a/announcements/_posts/2016-05-27-summer-new-meeting-time.md
+++ b/announcements/_posts/2016-05-27-summer-new-meeting-time.md
@@ -16,6 +16,6 @@ It may be summertime, but RITlug is still active over the summer! You can get mo
 
 * Facebook: https://www.facebook.com/groups/RITLUG/
 * Telegram: https://telegram.me/joinchat/BVxlKADKpMbhHtgxKkdjSQ
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 
 Looking forward to seeing you all next semester. If you're an alumni or just graduated, don't be a stranger! Visitors are always welcome, and if you'd like to give a talk sometime, you're always welcome to stop by. Thanks everyone!

--- a/announcements/_posts/2016-09-02-week-2-meeting.md
+++ b/announcements/_posts/2016-09-02-week-2-meeting.md
@@ -29,7 +29,7 @@ Whether you're joining us for the first time or the fifth time, there's multiple
 * Website:  http://ritlug.com
 * The Link: https://thelink.rit.edu/organization/Linux
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * Facebook: https://www.facebook.com/groups/RITLUG/
 
 If you join, make sure to say hello and let us know you're here!

--- a/announcements/_posts/2016-09-16-week-4-meeting.md
+++ b/announcements/_posts/2016-09-16-week-4-meeting.md
@@ -16,7 +16,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2016-09-30-week-6-meeting.md
+++ b/announcements/_posts/2016-09-30-week-6-meeting.md
@@ -21,7 +21,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2016-10-14-week-8-meeting.md
+++ b/announcements/_posts/2016-10-14-week-8-meeting.md
@@ -23,7 +23,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2016-10-27-week-10-meeting.md
+++ b/announcements/_posts/2016-10-27-week-10-meeting.md
@@ -23,7 +23,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2016-11-11-week-12-meeting.md
+++ b/announcements/_posts/2016-11-11-week-12-meeting.md
@@ -21,7 +21,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2016-11-18-week-13.md
+++ b/announcements/_posts/2016-11-18-week-13.md
@@ -25,7 +25,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2016-11-28-open-source-course.md
+++ b/announcements/_posts/2016-11-28-open-source-course.md
@@ -34,7 +34,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-01-12-week-1-meeting.md
+++ b/announcements/_posts/2017-01-12-week-1-meeting.md
@@ -28,7 +28,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-01-26-week-1-reminder.md
+++ b/announcements/_posts/2017-01-26-week-1-reminder.md
@@ -24,7 +24,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-02-01-week-2-backups.md
+++ b/announcements/_posts/2017-02-01-week-2-backups.md
@@ -29,7 +29,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-02-09-week-3.md
+++ b/announcements/_posts/2017-02-09-week-3.md
@@ -27,7 +27,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-02-17-week-4-windows-subsystem-for-linux.md
+++ b/announcements/_posts/2017-02-17-week-4-windows-subsystem-for-linux.md
@@ -28,7 +28,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: http://link.ritlug.com
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-02-23-Arch.md
+++ b/announcements/_posts/2017-02-23-Arch.md
@@ -31,7 +31,7 @@ RITlug on CampusGroups")
 If you join, make sure to say hello!
 
 To get the bare minimum news about RITlug, make sure you're a member of our
-[mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug 
+[mailing list]({{site.social.mailinglist}} "RITlug 
 mailing list - Google Groups"). This is the best way to receive future updates
 on what we're up to and where you can find us.
 

--- a/announcements/_posts/2017-02-24-week-5.md
+++ b/announcements/_posts/2017-02-24-week-5.md
@@ -24,7 +24,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-03-01-pi-group.md
+++ b/announcements/_posts/2017-03-01-pi-group.md
@@ -22,7 +22,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-03-02-week-6-arch.md
+++ b/announcements/_posts/2017-03-02-week-6-arch.md
@@ -27,7 +27,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-03-07-week-7-no-meeting-pi-group.md
+++ b/announcements/_posts/2017-03-07-week-7-no-meeting-pi-group.md
@@ -33,7 +33,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-03-22-week-8-our-cloud-infrastructure.md
+++ b/announcements/_posts/2017-03-22-week-8-our-cloud-infrastructure.md
@@ -34,7 +34,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-03-31-week-9.md
+++ b/announcements/_posts/2017-03-31-week-9.md
@@ -38,7 +38,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-04-07-week-10-Linux-Pranks.md
+++ b/announcements/_posts/2017-04-07-week-10-Linux-Pranks.md
@@ -40,7 +40,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-04-14-week-11.md
+++ b/announcements/_posts/2017-04-14-week-11.md
@@ -17,7 +17,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-04-14.md
+++ b/announcements/_posts/2017-04-14.md
@@ -15,7 +15,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-04-21-lightning-talks.md
+++ b/announcements/_posts/2017-04-21-lightning-talks.md
@@ -49,7 +49,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-04-28-imaginerit-elections.md
+++ b/announcements/_posts/2017-04-28-imaginerit-elections.md
@@ -40,7 +40,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-05-04-no-meeting.md
+++ b/announcements/_posts/2017-05-04-no-meeting.md
@@ -34,7 +34,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-05-12-OScon-Breif-Sticker-Swap.md
+++ b/announcements/_posts/2017-05-12-OScon-Breif-Sticker-Swap.md
@@ -26,7 +26,7 @@ You can find RITlug this year in a variety of places, but the best ways to keep 
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * The Link: https://thelink.rit.edu/organization/Linux
 * Facebook: https://www.facebook.com/groups/RITLUG/
 

--- a/announcements/_posts/2017-08-20-club-fair.md
+++ b/announcements/_posts/2017-08-20-club-fair.md
@@ -49,7 +49,7 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * Facebook: https://www.facebook.com/groups/RITLUG/
 
 If you join, make sure to say hello and let us know you're here!

--- a/announcements/_posts/2017-08-20-club-fair.md
+++ b/announcements/_posts/2017-08-20-club-fair.md
@@ -56,7 +56,7 @@ If you join, make sure to say hello and let us know you're here!
 
 To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our mailing list. This is the best way to receive future updates on what we're up to and where you can find us.
 
-**https://groups.google.com/forum/#!forum/ritlug-announce**
+**{{site.social.mailinglist}}**
 
 Looking forward to seeing you all soon, and safe travels to Rochester! Feel free to reach out if you have comments, questions, or concerns. And as always… keep the FOSS flag high!
 

--- a/announcements/_posts/2017-08-28-RITLUG-vF17.1-Welcome.md
+++ b/announcements/_posts/2017-08-28-RITLUG-vF17.1-Welcome.md
@@ -31,7 +31,7 @@ If you join, make sure to say hello and let us know you're here!
 
 To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our mailing list. This is the best way to receive future updates on what we're up to and where you can find us.
 
-**https://groups.google.com/forum/#!forum/ritlug-announce**
+**{{site.social.mailinglist}}**
 
 Good luck with your first week of classes, we're looking forward to meeting everyone! Feel free to reach out if you have comments, questions, or concerns. And as always… keep the FOSS flag high!
 

--- a/announcements/_posts/2017-08-28-RITLUG-vF17.1-Welcome.md
+++ b/announcements/_posts/2017-08-28-RITLUG-vF17.1-Welcome.md
@@ -24,7 +24,7 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * Facebook: https://www.facebook.com/groups/RITLUG/
 
 If you join, make sure to say hello and let us know you're here!

--- a/announcements/_posts/2017-09-07-RITLUG-vF17.2-Welcome.md
+++ b/announcements/_posts/2017-09-07-RITLUG-vF17.2-Welcome.md
@@ -31,7 +31,7 @@ If you join, make sure to say hello and let us know you're here!
 
 To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our mailing list. This is the best way to receive future updates on what we're up to and where you can find us.
 
-**https://groups.google.com/forum/#!forum/ritlug-announce**
+**{{site.social.mailinglist}}**
 
 
 Stay Fossy Folks,

--- a/announcements/_posts/2017-09-07-RITLUG-vF17.2-Welcome.md
+++ b/announcements/_posts/2017-09-07-RITLUG-vF17.2-Welcome.md
@@ -24,7 +24,7 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * Facebook: https://www.facebook.com/groups/RITLUG/
 
 If you join, make sure to say hello and let us know you're here!

--- a/announcements/_posts/2017-09-14-week-03-meeting.md
+++ b/announcements/_posts/2017-09-14-week-03-meeting.md
@@ -24,7 +24,7 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 
 * **Website**:  http://ritlug.com
 * **Telegram**: https://telegram.me/ritlugclub
-* **IRC**:      https://webchat.freenode.net/?channels=ritlug
+* **IRC**:      {{site.social.irc}}
 * **Facebook**: https://www.facebook.com/groups/RITLUG/
 
 If you join, make sure to say hello and let us know you're here!

--- a/announcements/_posts/2017-09-14-week-03-meeting.md
+++ b/announcements/_posts/2017-09-14-week-03-meeting.md
@@ -31,7 +31,7 @@ If you join, make sure to say hello and let us know you're here!
 
 To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our mailing list. This is the best way to receive future updates on what we're up to and where you can find us.
 
-**https://groups.google.com/forum/#!forum/ritlug-announce**
+**{{site.social.mailinglist}}**
 
 We hope to see you this Friday. As always, keep the FOSS flag high!
 

--- a/announcements/_posts/2017-09-16-TigerOS-mtg-organization.md
+++ b/announcements/_posts/2017-09-16-TigerOS-mtg-organization.md
@@ -21,7 +21,7 @@ If you join, make sure to say hello and let us know you're here!
 
 To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our mailing list. This is the best way to receive future updates on what we're up to and where you can find us.
 
-**https://groups.google.com/forum/#!forum/ritlug-announce**
+**{{site.social.mailinglist}}**
 
 
 May the light of FOSS shine upon you.

--- a/announcements/_posts/2017-09-16-TigerOS-mtg-organization.md
+++ b/announcements/_posts/2017-09-16-TigerOS-mtg-organization.md
@@ -14,7 +14,7 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 
 * Website:  http://ritlug.com
 * Telegram: https://telegram.me/ritlugclub
-* IRC:      https://webchat.freenode.net/?channels=ritlug
+* IRC:      {{site.social.irc}}
 * Facebook: https://www.facebook.com/groups/RITLUG/
 
 If you join, make sure to say hello and let us know you're here!

--- a/announcements/_posts/2017-09-18-week-04-meeting.md
+++ b/announcements/_posts/2017-09-18-week-04-meeting.md
@@ -39,9 +39,9 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 
 If you join, make sure to say hello!
 
-To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our [mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups"). This is the best way to receive future updates on what we're up to and where you can find us.
+To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our [mailing list]({{site.social.mailinglist}} "RITlug mailing list - Google Groups"). This is the best way to receive future updates on what we're up to and where you can find us.
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you this Friday. As always, keep the FOSS flag high!
 

--- a/announcements/_posts/2017-09-18-week-04-meeting.md
+++ b/announcements/_posts/2017-09-18-week-04-meeting.md
@@ -34,7 +34,7 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 * [CampusGroups](https://campusgroups.rit.edu/student_community?club_id=16071 "RITlug on CampusGroups")
 * [Website](http://ritlug.com "RIT Linux Users Group website")
 * [Telegram](https://t.me/ritlugclub "Join the Telegram group for RITlug")
-* [IRC](https://webchat.freenode.net/?channels=ritlug "Join the IRC channel for RITlug in a web client")
+* [IRC]({{site.social.irc}} "Join the IRC channel for RITlug in a web client")
 * [Facebook](https://www.facebook.com/groups/RITLUG/ "RITlug on Facebook - not super active!")
 
 If you join, make sure to say hello!

--- a/announcements/_posts/2017-09-29-week-05-meeting.md
+++ b/announcements/_posts/2017-09-29-week-05-meeting.md
@@ -49,9 +49,9 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 
 If you join, make sure to say hello!
 
-To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our [mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups"). This is the best way to receive future updates on what we're up to and where you can find us.
+To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our [mailing list]({{site.social.mailinglist}} "RITlug mailing list - Google Groups"). This is the best way to receive future updates on what we're up to and where you can find us.
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you today. Sorry for the late email reminder. As always, keep the FOSS flag high!
 

--- a/announcements/_posts/2017-09-29-week-05-meeting.md
+++ b/announcements/_posts/2017-09-29-week-05-meeting.md
@@ -44,7 +44,7 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 * [CampusGroups](https://campusgroups.rit.edu/student_community?club_id=16071 "RITlug on CampusGroups")
 * [Website](http://ritlug.com "RIT Linux Users Group website")
 * [Telegram](https://t.me/ritlugclub "Join the Telegram group for RITlug")
-* [IRC](https://webchat.freenode.net/?channels=ritlug "Join the IRC channel for RITlug in a web client")
+* [IRC]({{site.social.irc}} "Join the IRC channel for RITlug in a web client")
 * [Facebook](https://www.facebook.com/groups/RITLUG/ "RITlug on Facebook - not super active!")
 
 If you join, make sure to say hello!

--- a/announcements/_posts/2017-10-05-week-06-backups-and-infra.md
+++ b/announcements/_posts/2017-10-05-week-06-backups-and-infra.md
@@ -32,9 +32,9 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 
 If you join, make sure to say hello!
 
-To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our [mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups"). This is the best way to receive future updates on what we're up to and where you can find us.
+To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our [mailing list]({{site.social.mailinglist}} "RITlug mailing list - Google Groups"). This is the best way to receive future updates on what we're up to and where you can find us.
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you today. Sorry for the late email reminder. As always, keep the FOSS flag high!
 

--- a/announcements/_posts/2017-10-05-week-06-backups-and-infra.md
+++ b/announcements/_posts/2017-10-05-week-06-backups-and-infra.md
@@ -27,7 +27,7 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 * [CampusGroups](https://campusgroups.rit.edu/student_community?club_id=16071 "RITlug on CampusGroups")
 * [Website](http://ritlug.com "RIT Linux Users Group website")
 * [Telegram](https://t.me/ritlugclub "Join the Telegram group for RITlug")
-* [IRC](https://webchat.freenode.net/?channels=ritlug "Join the IRC channel for RITlug in a web client")
+* [IRC]({{site.social.irc}} "Join the IRC channel for RITlug in a web client")
 * [Facebook](https://www.facebook.com/groups/RITLUG/ "RITlug on Facebook - not super active!")
 
 If you join, make sure to say hello!

--- a/announcements/_posts/2017-10-16-week-08-meeting.md
+++ b/announcements/_posts/2017-10-16-week-08-meeting.md
@@ -39,9 +39,9 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 
 If you join, make sure to say hello!
 
-To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our [mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups"). This is the best way to receive future updates on what we're up to and where you can find us.
+To make sure you're in the loop with what's happening with RITlug, make sure you're a member of our [mailing list]({{site.social.mailinglist}} "RITlug mailing list - Google Groups"). This is the best way to receive future updates on what we're up to and where you can find us.
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you this week! As always, keep the FOSS flag high!
 

--- a/announcements/_posts/2017-10-16-week-08-meeting.md
+++ b/announcements/_posts/2017-10-16-week-08-meeting.md
@@ -34,7 +34,7 @@ RITlug is in a variety of places, but the best way to keep in touch with the com
 * [CampusGroups](https://campusgroups.rit.edu/student_community?club_id=16071 "RITlug on CampusGroups")
 * [Website](http://ritlug.com "RIT Linux Users Group website")
 * [Telegram](https://t.me/ritlugclub "Join the Telegram group for RITlug")
-* [IRC](https://webchat.freenode.net/?channels=ritlug "Join the IRC channel for RITlug in a web client")
+* [IRC]({{site.social.irc}} "Join the IRC channel for RITlug in a web client")
 * [Facebook](https://www.facebook.com/groups/RITLUG/ "RITlug on Facebook - not super active!")
 
 If you join, make sure to say hello!

--- a/announcements/_posts/2017-10-26-week-09-meeting.md
+++ b/announcements/_posts/2017-10-26-week-09-meeting.md
@@ -56,11 +56,11 @@ RITlug on CampusGroups")
 If you join, make sure to say hello!
 
 To get the bare minimum news about RITlug, make sure you're a member of our
-[mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug 
+[mailing list]({{site.social.mailinglist}} "RITlug 
 mailing list - Google Groups"). This is the best way to receive future updates
 on what we're up to and where you can find us.
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you this week! As always, keep the FOSS flag high!
 

--- a/announcements/_posts/2017-10-30-week-10-meeting.md
+++ b/announcements/_posts/2017-10-30-week-10-meeting.md
@@ -40,11 +40,11 @@ RITlug on CampusGroups")
 If you join, make sure to say hello!
 
 To get the bare minimum news about RITlug, make sure you're a member of our
-[mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug 
+[mailing list]({{site.social.mailinglist}} "RITlug 
 mailing list - Google Groups"). This is the best way to receive future updates
 on what we're up to and where you can find us.
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you this week! As always, keep the FOSS flag high!
 

--- a/announcements/_posts/2017-11-10-week-11-meeting.md
+++ b/announcements/_posts/2017-11-10-week-11-meeting.md
@@ -49,11 +49,11 @@ RITlug on CampusGroups")
 If you join, make sure to say hello!
 
 To get the bare minimum news about RITlug, make sure you're a **member of our
-[mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug 
+[mailing list]({{site.social.mailinglist}} "RITlug 
 mailing list - Google Groups")**. This is the best way to receive future updates
 on what we're up to and where you can find us.
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you this week! As always, keep the FOSS flag high!
 

--- a/announcements/_posts/2017-11-27-week-13-meeting.md
+++ b/announcements/_posts/2017-11-27-week-13-meeting.md
@@ -50,11 +50,11 @@ RITlug on CampusGroups")
 If you join, make sure to say hello!
 
 To get the bare minimum news about RITlug, make sure you're a member of our
-[mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug 
+[mailing list]({{site.social.mailinglist}} "RITlug 
 mailing list - Google Groups"). This is the best way to receive future updates
 on what we're up to and where you can find us.
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 
 ### Special thanks

--- a/announcements/_posts/2017-12-04-week-14-meeting.md
+++ b/announcements/_posts/2017-12-04-week-14-meeting.md
@@ -49,11 +49,11 @@ RITlug on CampusGroups")
 If you join, make sure to say hello!
 
 To get the bare minimum news about RITlug, make sure you're a member of our
-[mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug 
+[mailing list]({{site.social.mailinglist}} "RITlug 
 mailing list - Google Groups"). This is the best way to receive future updates
 on what we're up to and where you can find us.
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 
 We hope to see you this week! As always, keep the FOSS flag high.

--- a/announcements/_posts/2018-01-25-welcome-back.md
+++ b/announcements/_posts/2018-01-25-welcome-back.md
@@ -31,11 +31,11 @@ RITlug on CampusGroups")
 If you join, make sure to say hello!
 
 To get the bare minimum news about RITlug, make sure you're a member of our
-[mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug 
+[mailing list]({{site.social.mailinglist}} "RITlug 
 mailing list - Google Groups"). This is the best way to receive future updates
 on what we're up to and where you can find us.
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you this week! 
 May the light of FOSS shine upon you.

--- a/announcements/_posts/2018-01-29-homelab.md
+++ b/announcements/_posts/2018-01-29-homelab.md
@@ -29,11 +29,11 @@ RITlug on CampusGroups")
 If you join, make sure to say hello!
 
 To get the bare minimum news about RITlug, make sure you're a member of our
-[mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug 
+[mailing list]({{site.social.mailinglist}} "RITlug 
 mailing list - Google Groups"). This is the best way to receive future updates
 on what we're up to and where you can find us.
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 See you then!
 

--- a/announcements/_posts/2018-02-09-DarkWeb.md
+++ b/announcements/_posts/2018-02-09-DarkWeb.md
@@ -25,7 +25,7 @@ RITlug on CampusGroups")
 If you join, make sure to say hello!
 
 To get the bare minimum news about RITlug, make sure you're a member of our
-[mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug 
+[mailing list]({{site.social.mailinglist}} "RITlug 
 mailing list - Google Groups"). This is the best way to receive future updates
 on what we're up to and where you can find us.
 

--- a/announcements/_posts/2018-02-16-net-neutrality.md
+++ b/announcements/_posts/2018-02-16-net-neutrality.md
@@ -27,7 +27,7 @@ RITlug on CampusGroups")
 If you join, make sure to say hello!
 
 To get the bare minimum news about RITlug, make sure you're a member of our
-[mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug 
+[mailing list]({{site.social.mailinglist}} "RITlug 
 mailing list - Google Groups"). This is the best way to receive future updates
 on what we're up to and where you can find us.
 

--- a/announcements/_posts/2018-03-02-WeirdDistros.md
+++ b/announcements/_posts/2018-03-02-WeirdDistros.md
@@ -29,7 +29,7 @@ RITlug on CampusGroups")
 If you join, make sure to say hello!
 
 To get the bare minimum news about RITlug, make sure you're a member of our
-[mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug 
+[mailing list]({{site.social.mailinglist}} "RITlug 
 mailing list - Google Groups"). This is the best way to receive future updates
 on what we're up to and where you can find us.
 

--- a/announcements/_posts/2018-03-09-LinuxVideoGames.md
+++ b/announcements/_posts/2018-03-09-LinuxVideoGames.md
@@ -29,7 +29,7 @@ RITlug on CampusGroups")
 If you join, make sure to say hello!
 
 To get the bare minimum news about RITlug, make sure you're a member of our
-[mailing list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug 
+[mailing list]({{site.social.mailinglist}} "RITlug 
 mailing list - Google Groups"). This is the best way to receive future updates
 on what we're up to and where you can find us.
 

--- a/announcements/_posts/2018-03-21-week-09-meeting.md
+++ b/announcements/_posts/2018-03-21-week-09-meeting.md
@@ -48,10 +48,10 @@ If you join, make sure to say hello!
 
 The **mailing list** is the most important way to stay informed about RITlug.
 Make sure you're a member of our [mailing
-list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing
+list]({{site.social.mailinglist}} "RITlug mailing
 list - Google Groups").
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you this week!
 

--- a/announcements/_posts/2018-03-30-TigerOS.md
+++ b/announcements/_posts/2018-03-30-TigerOS.md
@@ -46,10 +46,10 @@ If you join, make sure to say hello!
 
 The **mailing list** is the most important way to stay informed about RITlug.
 Make sure you're a member of our [mailing
-list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing
+list]({{site.social.mailinglist}} "RITlug mailing
 list - Google Groups").
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you this week!
 

--- a/announcements/_posts/2018-04-02-week-11-meeting.md
+++ b/announcements/_posts/2018-04-02-week-11-meeting.md
@@ -48,10 +48,10 @@ If you join, make sure to say hello!
 
 The **mailing list** is the most important way to stay informed about RITlug.
 Make sure you're a member of our [mailing
-list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing
+list]({{site.social.mailinglist}} "RITlug mailing
 list - Google Groups").
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you this week! As always, keep the FOSS flag high.
 

--- a/announcements/_posts/2018-04-09-week-12-meeting.md
+++ b/announcements/_posts/2018-04-09-week-12-meeting.md
@@ -59,10 +59,10 @@ If you join, make sure to say hello!
 
 The **mailing list** is the most important way to stay informed about RITlug.
 Make sure you're a member of our [mailing
-list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing
+list]({{site.social.mailinglist}} "RITlug mailing
 list - Google Groups").
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you this week! As always, keep the FOSS flag high.
 

--- a/announcements/_posts/2018-04-16-week-13-meeting.md
+++ b/announcements/_posts/2018-04-16-week-13-meeting.md
@@ -46,10 +46,10 @@ If you join, make sure to say hello!
 
 The **mailing list** is the most important way to stay informed about RITlug.
 Make sure you're a member of our [mailing
-list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing
+list]({{site.social.mailinglist}} "RITlug mailing
 list - Google Groups").
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you this week! As always, keep the FOSS flag high.
 

--- a/announcements/_posts/2018-04-27-week-14-meeting.md
+++ b/announcements/_posts/2018-04-27-week-14-meeting.md
@@ -42,10 +42,10 @@ If you join, make sure to say hello!
 
 The **mailing list** is the most important way to stay informed about RITlug.
 Make sure you're a member of our [mailing
-list](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing
+list]({{site.social.mailinglist}} "RITlug mailing
 list - Google Groups").
 
-**[groups.google.com/forum/#!forum/ritlug-announce](https://groups.google.com/forum/#!forum/ritlug-announce "RITlug mailing list - Google Groups")**
+**[groups.google.com/forum/#!forum/ritlug-announce]({{site.social.mailinglist}} "RITlug mailing list - Google Groups")**
 
 We hope to see you this week!
 

--- a/announcements/_posts/2020-08-19-w01-welcome-back.md
+++ b/announcements/_posts/2020-08-19-w01-welcome-back.md
@@ -9,7 +9,7 @@ location: "Discord"
 
 Hello RITlug,
 
-Welcome back to RIT! We are glad to have you all back again this semester, even if you are not necessarily on campus. This semester we are going to be doing things a bit differently. Meetings will still be held Fridays from 4:30-6:00pm, however they will be conducted on our new [Discord Server](https://discord.gg/xev2W62). You can still reach out on the Slack channel, however this semester we will be primarily moving over to Discord. 
+Welcome back to RIT! We are glad to have you all back again this semester, even if you are not necessarily on campus. This semester we are going to be doing things a bit differently. Meetings will still be held Fridays from 4:30-6:00pm, however they will be conducted on our new [Discord Server]({{site.social.discord}}). You can still reach out on the Slack channel, however this semester we will be primarily moving over to Discord. 
 
 The meeting this Friday we will be holding a quick meet and greet with eboard and the other members of the club on the Discord. It will be a great way to catch up with everybody from last semester as well as meet some new members and learn about everybody's favorite things regarding Linux.
 

--- a/announcements/_posts/2020-08-25-w02-week-meeting.md
+++ b/announcements/_posts/2020-08-25-w02-week-meeting.md
@@ -13,7 +13,7 @@ I hope you are all doing alright, and the new semester has found you well so far
 
 This week at RITlug we will be having a super exciting, and potentially pretty challenging, puzzle involving all your favorite shell commands. So whether your new to the command line, a Bash boi, or a even ZSH wiz, we are sure you will get a kick out the activity.
 
-As a quick reminder, meetings this semester will all be taking place virtually on Fridays, 4:30pm - 6:00pm, via the new [Discord](https://discord.gg/xev2W62). Feel free to engage with us there, or continue to hangout with us on [Slack](rit-lug.slack.com) as well.
+As a quick reminder, meetings this semester will all be taking place virtually on Fridays, 4:30pm - 6:00pm, via the new [Discord]({{site.social.discord}}). Feel free to engage with us there, or continue to hangout with us on [Slack](rit-lug.slack.com) as well.
 
 I look forward to seeing you Friday! Stay safe, stay healthy.
 

--- a/announcements/archive.html
+++ b/announcements/archive.html
@@ -3,7 +3,7 @@ layout: default
 title: Announcements
 ---
 <div class="container">
-    <h1>Announcements <a href="https://groups.google.com/forum/#!forum/ritlug-announce"><i class="fas fa-envelope icon-orange"></i></a> <a href="/feeds/latest.xml"><i class="fas fa-rss-square icon-orange"></i></a></h1>
+    <h1>Announcements <a href="{{site.social.mailinglist}}"><i class="fas fa-envelope icon-orange"></i></a> <a href="/feeds/latest.xml"><i class="fas fa-rss-square icon-orange"></i></a></h1>
     {% for post in site.categories.announcements %}
       {% include content-blocks/post-preview.html %}
     {% endfor %}

--- a/announcements/index.html
+++ b/announcements/index.html
@@ -3,7 +3,7 @@ layout: default
 title: Announcements
 ---
 <div class="container">
-    <h1>Announcements <a href="https://groups.google.com/forum/#!forum/ritlug-announce"><i class="fas fa-envelope icon-orange"></i></a> <a href="/feeds/latest.xml"><i class="fas fa-rss-square icon-orange"></i></a></h1>
+    <h1>Announcements <a href="{{site.social.mailinglist}}"><i class="fas fa-envelope icon-orange"></i></a> <a href="/feeds/latest.xml"><i class="fas fa-rss-square icon-orange"></i></a></h1>
     {% comment %} 30 is roughly 2 semesters {% endcomment %}
     <p><em>
       RIT's email does not like the public list.

--- a/get-involved.html
+++ b/get-involved.html
@@ -81,7 +81,7 @@ title: Get Involved
             <h2>Chat</h2>
             <div class="list-group">
                 <a href="https://discord.gg/xev2W62" class="list-group-item list-group-item-action">Discord</a>
-                <a href="https://groups.google.com/forum/#!forum/ritlug-announce" class="list-group-item list-group-item-action">Mailing List (Google Group)</a>
+                <a href="{{site.social.mailinglist}}" class="list-group-item list-group-item-action">Mailing List (Google Group)</a>
                 <a href="{{site.social.irc}}" class="list-group-item list-group-item-action"><code>#ritlug</code> on IRC</a>
                 <a href="https://twitter.com/RITlug" class="list-group-item list-group-item-action">Twitter</a>
             </div>

--- a/get-involved.html
+++ b/get-involved.html
@@ -82,7 +82,7 @@ title: Get Involved
             <div class="list-group">
                 <a href="https://discord.gg/xev2W62" class="list-group-item list-group-item-action">Discord</a>
                 <a href="https://groups.google.com/forum/#!forum/ritlug-announce" class="list-group-item list-group-item-action">Mailing List (Google Group)</a>
-                <a href="https://webchat.freenode.net/?channels=ritlug" class="list-group-item list-group-item-action"><code>#ritlug</code> on IRC</a>
+                <a href="{{site.social.irc}}" class="list-group-item list-group-item-action"><code>#ritlug</code> on IRC</a>
                 <a href="https://twitter.com/RITlug" class="list-group-item list-group-item-action">Twitter</a>
             </div>
         </div>

--- a/get-involved.html
+++ b/get-involved.html
@@ -99,5 +99,5 @@ title: Get Involved
 </section>
 
 <h2>Questions?</h2>
-<p>Looking for more information? Contact us via <a href="mailto:{{ site.email }}">email</a> , Slack or IRC.</p>
+<p>Looking for more information? Contact us via <a href="mailto:{{ site.email }}">email</a> , Discord or IRC.</p>
 

--- a/get-involved.html
+++ b/get-involved.html
@@ -80,7 +80,7 @@ title: Get Involved
         <div class="col-12 col-md-6" style="margin-bottom:1.2em;">
             <h2>Chat</h2>
             <div class="list-group">
-                <a href="https://discord.gg/xev2W62" class="list-group-item list-group-item-action">Discord</a>
+                <a href="{{site.social.discord}}" class="list-group-item list-group-item-action">Discord</a>
                 <a href="{{site.social.mailinglist}}" class="list-group-item list-group-item-action">Mailing List (Google Group)</a>
                 <a href="{{site.social.irc}}" class="list-group-item list-group-item-action"><code>#ritlug</code> on IRC</a>
                 <a href="https://twitter.com/RITlug" class="list-group-item list-group-item-action">Twitter</a>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ title: Home
             <div class="list-group">
                 <a href="https://discord.gg/xev2W62" class="list-group-item list-group-item-action">Discord</a>
                 <a href="https://groups.google.com/forum/#!forum/ritlug-announce" class="list-group-item list-group-item-action">Mailing List (Google Group)</a>
-                <a href="https://webchat.freenode.net/?channels=ritlug" class="list-group-item list-group-item-action"><code>#ritlug</code> on IRC</a>
+                <a href="{{site.social.irc}}" class="list-group-item list-group-item-action"><code>#ritlug</code> on IRC</a>
                 <a href="https://twitter.com/RITlug" class="list-group-item list-group-item-action">Twitter</a>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ title: Home
         <div class="col-12 col-md-6" style="margin-bottom:1.2em;">
             <h2>Discuss</h2>
             <div class="list-group">
-                <a href="https://discord.gg/xev2W62" class="list-group-item list-group-item-action">Discord</a>
+                <a href="{{site.social.discord}}" class="list-group-item list-group-item-action">Discord</a>
                 <a href="{{site.social.mailinglist}}" class="list-group-item list-group-item-action">Mailing List (Google Group)</a>
                 <a href="{{site.social.irc}}" class="list-group-item list-group-item-action"><code>#ritlug</code> on IRC</a>
                 <a href="https://twitter.com/RITlug" class="list-group-item list-group-item-action">Twitter</a>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ title: Home
             <h2>Discuss</h2>
             <div class="list-group">
                 <a href="https://discord.gg/xev2W62" class="list-group-item list-group-item-action">Discord</a>
-                <a href="https://groups.google.com/forum/#!forum/ritlug-announce" class="list-group-item list-group-item-action">Mailing List (Google Group)</a>
+                <a href="{{site.social.mailinglist}}" class="list-group-item list-group-item-action">Mailing List (Google Group)</a>
                 <a href="{{site.social.irc}}" class="list-group-item list-group-item-action"><code>#ritlug</code> on IRC</a>
                 <a href="https://twitter.com/RITlug" class="list-group-item list-group-item-action">Twitter</a>
             </div>
@@ -38,7 +38,7 @@ title: Home
 
 
 <section class="container">
-    <h1>Latest News <a href="https://groups.google.com/forum/#!forum/ritlug-announce"><i class="fas fa-envelope icon-orange"></i></a> <a href="/feeds/latest.xml"><i class="fas fa-rss-square icon-orange"></i></a></h1>
+    <h1>Latest News <a href="{{site.social.mailinglist}}"><i class="fas fa-envelope icon-orange"></i></a> <a href="/feeds/latest.xml"><i class="fas fa-rss-square icon-orange"></i></a></h1>
 
     <p><em>
       RIT students, please subscribe on <a href="https://campusgroups.rit.edu/student_community?club_id=16071" target="_blank">CampusGroups</a>;

--- a/projects/_posts/2018-01-01-teleirc.md
+++ b/projects/_posts/2018-01-01-teleirc.md
@@ -40,7 +40,7 @@ A public Telegram supergroup and IRC channel (on freenode) are available for you
 to test. Our (small) development community is also found in these channels too.
 
 * **[Telegram](https://t.me/teleirc)**
-* **[IRC](https://webchat.freenode.net/?channels=ritlug-teleirc)** (#ritlug-teleirc @ irc.freenode.net)
+* **[IRC]({{site.social.irc}}-teleirc)** (#ritlug-teleirc @ irc.freenode.net)
 
 ### Who uses TeleIRC?
 


### PR DESCRIPTION
This puts a couple social links into `_config.yml` (discord, IRC, and mailing list) to make them easy to potentially change in future.

The original goal was to update the IRC links but i realized #rit-foss and #ritlug are different


THis PR also includes some pretty indiscriminant find and replace